### PR TITLE
Circle CI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,39 @@
+version: 2.1
+
+orbs:
+  node: circleci/node@5.0.3
+
+ignore_forks: &ignore_forks
+  branches:
+    # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+    ignore: /pull\/[0-9]+/
+
+only_forks: &only_forks
+  branches:
+    # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+    only: /pull\/[0-9]+/
+
+jobs:
+  test:
+    executor:
+      name: node/default
+      tag: '16.16'
+    steps:
+      - checkout
+      - node/install-packages:
+          pkg-manager: yarn
+      - run:
+          command: yarn run test
+          name: Run the ESLint plugin tests
+
+workflows:
+  test_from_branches:
+    jobs:
+      - test:
+          filters:
+            <<: *ignore_forks
+  test_from_forks:
+    jobs:
+      - test:
+          filters:
+            <<: *only_forks

--- a/package.json
+++ b/package.json
@@ -77,5 +77,12 @@
         "tabWidth": 4,
         "singleQuote": true,
         "trailingComma": "none"
+    },
+    "engines": {
+        "node": ">=14"
+    },
+    "volta": {
+        "node": "16.17.1",
+        "yarn": "1.22.19"
     }
 }


### PR DESCRIPTION
It seems to be a chicken-and-egg problem to get this first CircleCI configuration running on this repo—I have to "set up" the project in CircleCI to get checks to run, but that requires having a `config.yml` file committed, as near as I can tell.

I validated this PR by setting up CircleCI on my own (khawkins) Org, and everything seems to be working as expected. It's pretty basic for this repo: install and test, nothing more to do.