### PR TITLE
Default namespace to 'c'.

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -74,7 +74,7 @@ function preprocess(text, filename) {
     } else {
         let eslintReports = staticAnalyzer.generatePrimingDiagnosticsModule({
             type: 'bundle',
-            namespace: 'lightning',
+            namespace: 'c',
             name: bundleBaseFileWithoutExtension,
             files: files
         });


### PR DESCRIPTION
Default namespace should use `c` as described in this [doc](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.create_components_namespace). Verified that test runs successfully with the namespace change and that the eslint plugin correctly identifies LWC offline-ability.

In the next iteration of `eslint-plugin-lwc-graph-analyzer`, where the development will take place in the `dev` branch, a new feature will be added to override `c` from the plugin's configuration.