### PR TITLE
Static Analyzer docs

### DIFF
--- a/lib/docs/no-assignment-expression-assigns-value-to-member-variable.md
+++ b/lib/docs/no-assignment-expression-assigns-value-to-member-variable.md
@@ -1,0 +1,31 @@
+# no-assignment-expression-assigns-value-to-member-variable
+
+ This rule flags getters in custom components that mutate properties, which prevents the static analyzer from being able to determine a value for the property when priming. To resolve this error, don’t assign or mutate member variables in your getter functions.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    prop;
+    get input() {
+        const value = 'value';
+        this.prop = value;
+        return value;
+    }
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    prop;
+    get input() {
+        return 'value';
+    }
+}
+```
+
+

--- a/lib/docs/no-assignment-expression-for-external-components.md
+++ b/lib/docs/no-assignment-expression-for-external-components.md
@@ -1,0 +1,30 @@
+# no-assignment-expression-for-external-components
+
+This rule flags assignment expressions with components created outside of a Salesforce namespace. These external components aren’t supported by assignment expressions.
+
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    prop;
+    get getter() {
+        return (this.prop = 'hi'), this.prop;
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api prop;
+    get getter() {
+        return this.prop;
+    }
+}
+
+```

--- a/lib/docs/no-call-expression-references-unsupported-namespace.md
+++ b/lib/docs/no-call-expression-references-unsupported-namespace.md
@@ -1,0 +1,24 @@
+# no-call-expression-references-unsupported-namespace
+
+This rule flags getters that invoke a function from an unsupported import. Getters don’t support invoking functions. To resolve this error, review the getter and remove the invocation of functions.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+import invalid from 'x/invalid';
+export default class Example extends LightningElement {
+    get invalidGetter() {
+        return invalid();
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {}
+
+```

--- a/lib/docs/no-class-refers-to-parent-class-from-unsupported-namespace.md
+++ b/lib/docs/no-class-refers-to-parent-class-from-unsupported-namespace.md
@@ -1,0 +1,21 @@
+# no-class-refers-to-parent-class-from-unsupported-namespace
+
+This rule flags components that extend from a parent class that’s not supported for Lightning web components, such as a custom class. 
+
+## ❌ Incorrect
+
+```javascript
+import Foo from './foo';
+
+export default class Example extends Foo {}
+
+```
+
+## ✅ Correct
+
+```javascript
+import Foo from 'lightning/recordForm';
+
+export default class Example extends Foo {}
+
+```

--- a/lib/docs/no-composition-on-unanalyzable-getter-property.md
+++ b/lib/docs/no-composition-on-unanalyzable-getter-property.md
@@ -1,0 +1,44 @@
+# no-composition-on-unanalyzable-getter-property
+
+This rule flags iterators, image `src` attributes, or child components that reference an unanalyzable getter. To resolve this error, review the referenced getter and make sure that it’s valid. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    prop;
+    get invalidGetter() {
+        this.prop = 'new value'; // mutations not allowed
+        return this.prop;
+    }
+}
+
+```
+
+```html
+<template>
+    <c-child input={invalidGetter}></c-child>
+</template>
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api prop;
+    get getter() {
+        return this.prop;
+    }
+}
+
+```
+
+```html
+<template>
+    <c-child input={getter}></c-child>
+</template>
+
+```

--- a/lib/docs/no-composition-on-unanalyzable-property-from-unresolvable-wire.md
+++ b/lib/docs/no-composition-on-unanalyzable-property-from-unresolvable-wire.md
@@ -1,0 +1,41 @@
+# no-composition-on-unanalyzable-property-from-unresolvable-wire
+
+This rule flags iterators, image `src` attributes, or child components of an LWC template that reference an unanalyzable property, such as an invalid getter, or a wire output from an unsupported or unprimeable wire. To resolve this error, review the property reference and the referenced variable to make sure they’re both valid.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { invalid } from 'x/invalid';
+export default class Example extends LightningElement {
+    @wire(invalid, {})
+    wireOutput;
+}
+
+```
+
+```html
+<template>
+    <c-child input={wireOutput}></c-child>
+</template>
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+export default class Example extends LightningElement {
+    @wire(getRecord, {})
+    wireOutput;
+}
+
+```
+
+```html
+<template>
+    <c-child input={wireOutput}></c-child>
+</template>
+
+```

--- a/lib/docs/no-composition-on-unanalyzable-property-missing.md
+++ b/lib/docs/no-composition-on-unanalyzable-property-missing.md
@@ -1,0 +1,73 @@
+# no-composition-on-unanalyzable-property-missing
+
+This rule flags iterators, image `src` attributes, or child components that reference a property that’s not found in the JavaScript file. This rule also flags a child class that references a property that’s only defined on the parent class. To resolve this error, review the referenced properties and make sure that they’re correctly defined.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {}
+
+```
+
+```html
+<template>
+    <c-child input={doesNotExist}></c-child>
+</template>
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api doesExist;
+}
+
+```
+
+```html
+<template>
+    <c-child input={doesExist}></c-child>
+</template>
+
+```
+
+## 😟 Limitations
+
+This rule flags a child class that references a property that’s only defined on the parent class.
+
+### ❌ Incorrect
+
+```javascript
+import Parent from 'x/parent';
+export default class Example extends Parent {}
+
+```
+
+```html
+<template>
+    <c-child input={existsOnParent}></c-child>
+</template>
+
+```
+
+### ✅ Correct
+
+Update the JavaScript file to explicitly define properties that are referenced in the template.
+
+```javascript
+import Parent from 'x/parent';
+export default class Example extends Parent {
+    @api existsOnParent;
+}
+
+```
+
+```html
+<template>
+    <c-child input={existsOnParent}></c-child>
+</template>
+
+```

--- a/lib/docs/no-composition-on-unanalyzable-property-non-public.md
+++ b/lib/docs/no-composition-on-unanalyzable-property-non-public.md
@@ -1,0 +1,37 @@
+# no-composition-on-unanalyzable-property-non-public
+
+This rule flags iterators, image `src` attributes, or child components that reference a property that isn’t public. To resolve this error, review the referenced property to make sure that it’s public and valid.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    notPublic;
+}
+
+```
+
+```html
+<template>
+    <c-child input={notPublic}></c-child>
+</template>
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api public;
+}
+
+```
+
+```html
+<template>
+    <c-child input={public}></c-child>
+</template>
+
+```

--- a/lib/docs/no-eval-usage.md
+++ b/lib/docs/no-eval-usage.md
@@ -1,0 +1,27 @@
+# no-eval-usage
+
+This rule flags getters that use the `eval` function. To resolve this error, review the getter and refactor it to remove the `eval` function.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get invalid() {
+        return eval('something evil');
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get valid() {
+        return 'do no evil';
+    }
+}
+
+```

--- a/lib/docs/no-expression-contains-module-level-variable-ref.md
+++ b/lib/docs/no-expression-contains-module-level-variable-ref.md
@@ -1,0 +1,31 @@
+# no-expression-contains-module-level-variable-ref
+
+This rule flags getters that reference a variable defined at the module level. To resolve this error, remove the variable from the module level. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+const moduleValue = 'val';
+export default class Example extends LightningElement {
+    get invalid() {
+        return moduleValue;
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get propValue() {
+        return 'val';
+    }
+    get valid() {
+        return this.propValue;
+    }
+}
+
+```

--- a/lib/docs/no-functions-declared-within-getter-method.md
+++ b/lib/docs/no-functions-declared-within-getter-method.md
@@ -1,0 +1,33 @@
+# no-functions-declared-within-getter-method
+
+This rule flags getters or template expressions that define a function. To resolve this error, remove the function that’s defined within the getter.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+
+export default class Example extends LightningElement {
+    get value() {
+        return (() => 'value')(); // flags
+    }
+
+    str = `${(() => 'value')()}`; // flags
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+
+export default class Example extends LightningElement {
+    get value() {
+        return 'value';
+    }
+
+    str = `value`;
+}
+
+```

--- a/lib/docs/no-getter-contains-more-than-return-statement.md
+++ b/lib/docs/no-getter-contains-more-than-return-statement.md
@@ -1,0 +1,28 @@
+# no-getter-contains-more-than-return-statement
+
+This rule flags getters that do more than just return a value. To resolve this error, review the getters and make sure that they’re composed to only return a value. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get invalidGetter() {
+        const val = 'val';
+        return val;
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get invalidGetter() {
+        return 'val';
+    }
+}
+
+```

--- a/lib/docs/no-member-expression-contains-non-portable-identifier.md
+++ b/lib/docs/no-member-expression-contains-non-portable-identifier.md
@@ -1,0 +1,29 @@
+# no-member-expression-contains-non-portable-identifier
+
+This rule flags expressions that contain a non-portable variable like `document` or `window`. To resolve this error, refactor your code to remove non-portable variables.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get value() {
+        return window.foo;
+    }
+
+    str = `${window.foo}`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+	get value() {
+	    return ‘foo’; // This expression is valid because it isn’t using a global variable, such as window or document 
+    }
+}
+
+```

--- a/lib/docs/no-member-expression-reference-to-non-existent-member-variable.md
+++ b/lib/docs/no-member-expression-reference-to-non-existent-member-variable.md
@@ -1,0 +1,32 @@
+# no-member-expression-reference-to-non-existent-member-variable
+
+This rule flags expressions that reference a member variable that’s not defined. To resolve this error, review the member variable and make sure that it’s defined correctly.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get value() {
+        return this.doesNotExist;
+    }
+
+    otherValue = `${this.doesNotExist}`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api doesExist;
+    get value() {
+        return this.doesExist;
+    }
+
+    otherValue = `${this.doesExist}`;
+}
+
+```

--- a/lib/docs/no-member-expression-reference-to-super-class.md
+++ b/lib/docs/no-member-expression-reference-to-super-class.md
@@ -1,0 +1,32 @@
+# no-member-expression-reference-to-super-class
+
+This rule flags expressions that reference a superclass. To resolve this error, remove the `super` reference and explicitly define the referenced property in the class.
+
+## ❌ Incorrect
+
+```javascript
+import Parent from 'x/parent';
+export default class Example extends Parent {
+    get value() {
+        return super.value;
+    }
+
+    str = `${super.value}`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import Parent from 'x/parent';
+export default class Example extends Parent {
+    @api value; // value is explicitly defined in the Example class
+    get value() {
+        return this.value;
+    }
+
+    str = `${this.value}`;
+}
+
+```

--- a/lib/docs/no-member-expression-reference-to-unsupported-global.md
+++ b/lib/docs/no-member-expression-reference-to-unsupported-global.md
@@ -1,0 +1,25 @@
+# no-member-expression-reference-to-unsupported-global
+
+This rule flags expressions that reference a global variable, such as `String` or `Object`. To resolve this error, refactor your code to remove the global variables.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get value() {
+        return new String.foo();
+    }
+
+    str = `${String.foo}`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {}
+
+```

--- a/lib/docs/no-member-expression-reference-to-unsupported-namespace-reference.md
+++ b/lib/docs/no-member-expression-reference-to-unsupported-namespace-reference.md
@@ -1,0 +1,26 @@
+# no-member-expression-reference-to-unsupported-namespace-reference
+
+This rule flags expressions that reference a module that isn’t supported. To resolve this error, make sure to reference modules that are imported from a Salesforce package.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+import invalid from 'x/invalid';
+export default class Example extends LightningElement {
+    get value() {
+        return invalid.foo;
+    }
+
+    str = `${invalid.foo}`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {}
+
+```

--- a/lib/docs/no-missing-resource-cannot-prime-wire-adapter.md
+++ b/lib/docs/no-missing-resource-cannot-prime-wire-adapter.md
@@ -1,0 +1,27 @@
+# no-missing-resource-cannot-prime-wire-adapter
+
+This rule flags wire adapters that refer to a resource that isn’t defined. To resolve this error, review the referenced resource and make sure that the resource is imported or defined correctly. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+
+export default class ScriptTestClass extends LightningElement {
+    // getRecord has not been imported
+    @wire(getRecord, {})
+    record;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+
+export default class ScriptTestClass extends LightningElement {
+    @wire(getRecord, {})
+    record;
+}
+```

--- a/lib/docs/no-multiple-template-files.md
+++ b/lib/docs/no-multiple-template-files.md
@@ -1,0 +1,27 @@
+# no-multiple-template-files
+
+This rule flags components that use more than one template file, because Static Analyzer can’t analyze components with more than one template file. Lightning web components can use more than one template, but it’s not recommended. For more information, see [Render Multiple Templates](https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.create_render) in the *Lightning Web Components Dev Guide*.
+
+## ❌ Incorrect
+
+```javascript
+// example.js
+import { LightningElement } from 'lwc';
+import tmpl1 from './example.html';
+import tmpl2 from './example.2.html';
+export default class Example extends LightningElement {
+    @api someInput;
+    render() {
+        return this.someInput ? tmpl1 : tmpl2;
+    }
+}
+```
+
+```html
+<!-- example.html -->
+<template></template>
+<!-- example.2.html -->
+<template></template>
+<!-- flags -->
+
+```

--- a/lib/docs/no-private-wire-config-property.md
+++ b/lib/docs/no-private-wire-config-property.md
@@ -1,0 +1,51 @@
+# no-private-wire-config-property
+
+This rule flags wire configurations that use a private property. Private properties in wire configurations aren’t resolvable. To resolve this error, make the property public or use a property that’s already public. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+
+export default class Example extends LightningElement {
+    recordId;
+
+    @wire(getRecord, { recordId: '$recordId' })
+    record;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+
+export default class Example extends LightningElement {
+    @api recordId;
+
+    @wire(getRecord, { recordId: '$recordId' })
+    record;
+}
+```
+
+## 😟 Limitations
+
+Public properties decorated with `@api` can't be reassigned.
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+
+export default class Example extends LightningElement {
+    recordId; // recordId can't have the @api declaration because the property is mutated below
+
+    connectedCallback() {
+        this.recordId = '1234'; // Prevents recordId from being made public
+    }
+
+    @wire(getRecord, { recordId: '$recordId' })
+    record;
+}
+```

--- a/lib/docs/no-reference-to-class-functions.md
+++ b/lib/docs/no-reference-to-class-functions.md
@@ -1,0 +1,38 @@
+# no-reference-to-class-functions
+
+This rule flags call expressions that reference a function defined in a class. These functions are not supported. To resolve this error, replace the function defined in the class with a getter. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    doSomething() {
+        return 'value';
+    }
+
+    get value() {
+        return this.doSomething(); // flags
+    }
+
+    someProp = `${this.doSomething()}`; // flags
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    get something() {
+        return 'value';
+    }
+    get value() {
+        return this.something;
+    }
+
+    someProp = `${this.something}`;
+}
+
+```

--- a/lib/docs/no-reference-to-module-functions.md
+++ b/lib/docs/no-reference-to-module-functions.md
@@ -1,0 +1,43 @@
+# no-reference-to-module-functions
+
+This rule flags call expressions that reference a function defined in a module. These functions are not supported. To resolve this error, replace the function defined in the module with a getter.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+
+// Module level function
+function doSomething() {
+    return 'value';
+}
+
+export default class Example extends LightningElement {
+    get value() {
+        return doSomething(); // flags
+    }
+
+    someProp = `${doSomething()}`; // flags
+}
+
+```
+
+## ✅ Correct
+
+Replace with a getter if you can.
+
+```javascript
+import { LightningElement } from 'lwc';
+
+export default class Example extends LightningElement {
+    get something() {
+        return 'value';
+    }
+    get value() {
+        return this.something;
+    }
+
+    someProp = `${this.something}`;
+}
+
+```

--- a/lib/docs/no-reference-to-unsupported-namespace-reference.md
+++ b/lib/docs/no-reference-to-unsupported-namespace-reference.md
@@ -1,0 +1,29 @@
+# no-reference-to-unsupported-namespace-reference
+
+This rule flags expressions that use a resource imported from an unsupported namespace. To resolve this error, review the imported resources and make sure that they’re imported from supported namespaces like `@salesforce/*`.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+import invalid from 'x/invalid';
+export default class Example extends LightningElement {
+    get value() {
+        return invalid;
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+import valid from '@salesforce/label/My.Label';
+export default class Example extends LightningElement {
+    get value() {
+        return valid;
+    }
+}
+
+```

--- a/lib/docs/no-render-function-contains-more-than-return-statement.md
+++ b/lib/docs/no-render-function-contains-more-than-return-statement.md
@@ -1,0 +1,31 @@
+# no-render-function-contains-more-than-return-statement
+
+This rule flags render functions that do more than just return a value. To resolve this error, review the functions and make sure that they’re composed to only return a value. 
+
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+import template from './tesTemplate.html';
+export default class Example extends LightningElement {
+    render() {
+        const val = 'val';
+        return val ? template : undefined;
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+import template from './tesTemplate.html';
+export default class Example extends LightningElement {
+    render() {
+        return template;
+    }
+}
+
+```

--- a/lib/docs/no-render-function-return-statement-not-returning-imported-template.md
+++ b/lib/docs/no-render-function-return-statement-not-returning-imported-template.md
@@ -1,0 +1,43 @@
+# no-render-function-return-statement-not-returning-imported-template
+
+This rule flags render functions that return a value that’s not an imported local template. To resolve this error, review the function and make sure that its return statement returns a supported imported template.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, api } from 'lwc';
+import template from 'lightning/something';
+export default class Example extends LightningElement {
+    @api
+    firstOrSecondTemplate;
+
+
+    @api
+    passedInTemplate;
+
+
+    render() {
+        return this.firstOrSecondTemplate
+            ? this.passedInTemplate // not supported because it's passed through the prop
+            : template; // not supported because it's imported from another module
+    }
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, api } from 'lwc';
+import firstTemplate from './firstTemplate.html';
+import secondTemplate from './secondTemplate.html';
+export default class Example extends LightningElement {
+    @api
+    firstOrSecondTemplate;
+
+
+    render() {
+        return this.firstOrSecondTemplate ? firstTemplate : secondTemplate;
+    }
+}
+
+```

--- a/lib/docs/no-render-function-return-statement.md
+++ b/lib/docs/no-render-function-return-statement.md
@@ -1,0 +1,30 @@
+# no-render-function-return-statement
+
+This rule flags render functions that don’t have a return statement. To resolve this error, review the functions and make sure that they’re composed with a return statement. 
+
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    render() {
+        const val = 'val';
+    }
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+import template from './tesTemplate.html';
+export default class Example extends LightningElement {
+    render() {
+        return template;
+    }
+}
+
+
+```

--- a/lib/docs/no-tagged-template-expression-contains-unsupported-namespace.md
+++ b/lib/docs/no-tagged-template-expression-contains-unsupported-namespace.md
@@ -1,0 +1,27 @@
+# no-tagged-template-expression-contains-unsupported-namespace
+
+This rule flags template expression tags that are from an unsupported resource. To resolve this error, review the tags in the template expression and make sure that they’re defined correctly. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+import invalid from 'x/invalid';
+
+export default class Example extends LightningElement {
+    invalidProp = invalid`normal string`;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+import { gql } from 'lightning/uiGraphQLApi';
+
+export default class Example extends LightningElement {
+    validProp = gql`normal string`;
+}
+
+```

--- a/lib/docs/no-unresolved-parent-class-reference.md
+++ b/lib/docs/no-unresolved-parent-class-reference.md
@@ -1,0 +1,31 @@
+# no-unresolved-parent-class-reference
+
+ This rule flags a class that references an unresolvable parent class. To resolve this error, review the parent class and make sure that the class is defined and imported correctly. 
+
+## ❌ Incorrect
+
+```javascript
+const Foo = {}; // Foo is defined, but not a class
+export default class Example extends Foo {} // flags
+// Foo is not defined at all
+export default class Example extends Foo {} // flags
+```
+
+## ✅ Correct
+
+```javascript
+import Foo from 'x/foo';
+export default class Example extends Foo {}
+```
+
+## 😟 Limitations
+
+Using mixins with a parent class is currently not supported.
+
+```javascript
+import Foo from 'x/foo';
+import Mixin from 'x/mixin';
+
+export default class Example extends Mixin(Foo) {}
+
+```

--- a/lib/docs/no-unsupported-member-variable-in-member-expression.md
+++ b/lib/docs/no-unsupported-member-variable-in-member-expression.md
@@ -1,0 +1,35 @@
+# no-unsupported-member-variable-in-member-expression
+
+This rule flags getter or template expressions that reference an unsupported or private member variable. To resolve this error, review the member variable definition and make sure that it’s public. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    privateProp; // unsupported member variable
+
+    get value() {
+        return this.privateProp; // flags
+    }
+
+    otherValue = `${this.privateProp}`; // flags
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api prop;
+
+    get value() {
+        return this.prop;
+    }
+
+    otherValue = `${this.prop}`;
+}
+
+```

--- a/lib/docs/no-wire-adapter-of-resource-cannot-be-primed.md
+++ b/lib/docs/no-wire-adapter-of-resource-cannot-be-primed.md
@@ -1,0 +1,35 @@
+# no-wire-adapter-of-resource-cannot-be-primed
+
+This rule flags wires that are invalid because the wire adapter can’t be primed for offline use. Only wires from valid resources, such as (Lightning Data Service wires)[https://developer.salesforce.com/docs/component-library/documentation/en/lwc/lwc.reference_ui_api] in the `lightning` namespace, are allowed. You can ignore this error if the wire you’re using doesn’t need to be primed for offline use. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { invalid } from 'x/invalid';
+import { alsoInvalid } from './invalid'; //
+
+export default class Example extends LightningElement {
+    @wire(invalid, {})
+    wireOutput1;
+
+    @wire(alsoInvalid, {})
+    wireOutput2;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import { getObjectInfo } from 'lightning/uiObjectInfoApi';
+
+export default class Example extends LightningElement {
+    @wire(getRecord, {})
+    wireOutput1;
+
+    @wire(getObjectInfo, {})
+    wireOutput2;
+}
+```

--- a/lib/docs/no-wire-config-property-circular-wire-dependency.md
+++ b/lib/docs/no-wire-config-property-circular-wire-dependency.md
@@ -1,0 +1,30 @@
+# no-wire-config-property-circular-wire-dependency
+
+This rule flags circular dependencies that occur when a wire’s output is an input into another wire, and that wire’s output is an input into the original wire. Circular dependencies cause an infinite loop during runtime. To resolve this error, review the flagged dependency chain and refactor the code to remove the circular dependency.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+export default class Example extends LightningElement {
+    @wire(getRecord, { input: '$wireOutput2' })
+    wireOutput1;
+
+    @wire(getRecord, { input: '$wireOutput1' })
+    wireOutput2;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement } from 'lwc';
+export default class Example extends LightningElement {
+    @api input;
+    @wire(getRecord, { input: '$input' })
+    wireOutput;
+}
+
+```

--- a/lib/docs/no-wire-config-property-uses-getter-function-returning-inaccessible-import.md
+++ b/lib/docs/no-wire-config-property-uses-getter-function-returning-inaccessible-import.md
@@ -1,0 +1,37 @@
+# no-wire-config-property-uses-getter-function-returning-inaccessible-import
+
+This rule flags wire configurations using a getter that imports an unknown resource. To resolve this error, make sure that the wires are importing only known and valid resources, such as resources imported from `@salesforce/*`. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import { invalid } from 'x/invalid';
+
+export default class ScriptTestClass extends LightningElement {
+    get label() {
+        return invalid;
+    }
+
+    @wire(getRecord, { label: '$label' })
+    record1;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import myLabel from '@salesforce/label/My.Label';
+
+export default class ScriptTestClass extends LightningElement {
+    get label() {
+        return myLabel;
+    }
+
+    @wire(getRecord, { label: '$label' })
+    record1;
+}
+```

--- a/lib/docs/no-wire-config-property-uses-getter-function-returning-non-literal.md
+++ b/lib/docs/no-wire-config-property-uses-getter-function-returning-non-literal.md
@@ -1,0 +1,36 @@
+# no-wire-config-property-uses-getter-function-returning-non-literal
+
+This rule flags wire configurations using a getter that returns a non-literal value, which isn’t supported for static analysis. If the flagged component is intended for offline use, refactor the getter to return a literal value, or remove the getter that returns a non-literal value. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+export default class Example extends LightningElement {
+    prop; // unsupported
+    get value() {
+        return this.prop;
+    }
+
+    @wire(getRecord, { input: '$value' }) // flags
+    record;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+export default class Example extends LightningElement {
+    get value() {
+    return "abcd1234";
+    }
+    }
+
+    @wire(getRecord, { input: '$value' }) // flags
+    record;
+}
+
+```

--- a/lib/docs/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.md
+++ b/lib/docs/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.md
@@ -1,0 +1,31 @@
+# no-wire-config-property-uses-imported-artifact-from-unsupported-namespace
+
+This rule flags wire configurations that reference an imported artifact that’s not from a supported resource. To resolve this error, make sure that the wires reference only supported and valid resources, such as artifacts imported from `@salesforce/*`.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import invalid from 'x/invalid';
+
+export default class Example extends LightningElement {
+    @wire(getRecord, { label: invalid })
+    records;
+}
+
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import label from '@salesforce/label/My.Label';
+
+export default class Example extends LightningElement {
+    @wire(getRecord, { recordId: label })
+    records;
+}
+
+```

--- a/lib/docs/no-wire-config-references-non-local-property-reactive-value.md
+++ b/lib/docs/no-wire-config-references-non-local-property-reactive-value.md
@@ -1,0 +1,65 @@
+# no-wire-config-references-non-local-property-reactive-value
+
+This rule flags wire configurations with reactive values (‘`$prop`’) that are not local properties. Wire configurations with reactive values must reference only component properties. To resolve this error, review the reactive values and make sure that they don’t reference imported values, or other values defined outside of the component’s class. Alternatively, you can wrap the imported artifact delivery in a local property getter function.
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import label from '@salesforce/label/My.Label';
+
+export default class Example extends LightningElement {
+    @wire(getRecord, { recordId: '$label' })
+    records;
+}
+
+```
+
+## ✅ Correct
+
+Reference the value directly.
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import label from '@salesforce/label/My.Label';
+
+export default class Example extends LightningElement {
+    @wire(getRecord, { recordId: label })
+    records;
+}
+
+```
+
+Or, set the value to a property before referencing the value.
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import label from '@salesforce/label/My.Label';
+
+export default class Example extends LightningElement {
+    @api label;
+    @wire(getRecord, { recordId: '$label' })
+    records;
+}
+
+```
+
+Or, use a getter that returns the value.
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import label from '@salesforce/label/My.Label';
+
+export default class Example extends LightningElement {
+    get label() {
+        return label;
+    }
+    @wire(getRecord, { recordId: '$label' })
+    records;
+}
+
+```

--- a/lib/docs/no-wire-configuration-property-using-output-of-non-primeable-wire.md
+++ b/lib/docs/no-wire-configuration-property-using-output-of-non-primeable-wire.md
@@ -1,0 +1,41 @@
+# no-wire-configuration-property-using-output-of-non-primeable-wire
+
+This rule flags wire configurations that reference the output of a wire that can’t be analyzed. This rule flags any wire that uses input from another wire that can’t be primed for offline use or caching. To resolve this error, review the related wires to make sure they’re known and valid. 
+
+## ❌ Incorrect
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { invalid } from 'x/invalid';
+import { getObjectInfo } from 'lightning/uiObjectInfoApi';
+
+export default class Example extends LightningElement {
+    // This wire is invalid because of another rule, such as no-wire-adapter-of-resource-cannot-be-primed, so its associated property can’t be referenced by another wire
+    @wire(invalid, {}) 
+    wiredOutput1;
+
+    // Since "invalid" is not primable, its output "wiredOutput1.data" 
+    // cannot be used as input in another wire
+    @wire(getObjectInfo, { input: '$wiredOutput1.data' })
+    wiredOutput2;
+}
+```
+
+## ✅ Correct
+
+```javascript
+import { LightningElement, wire, api } from 'lwc';
+import { getRecord } from 'lightning/uiRecordApi';
+import { getObjectInfo } from 'lightning/uiObjectInfoApi';
+
+export default class Example extends LightningElement {
+    // "getRecord" from "lightning/uiRecordApi" is a known wire, and 
+    // thus primeable
+    @wire(getRecord, {})
+    wiredOutput1;
+
+    // valid
+    @wire(getObjectInfo, { input: '$wiredOutput1.data' })
+    wiredOutput2;
+}
+```


### PR DESCRIPTION
…plate.md

Create no-unresolved-parent-class-reference.md

Create no-multiple-template-files.md

Create no-private-wire-config-property.md

Create no-conditional-using-property-from-unresolvable-wire.md

Create no-wire-configuration-property-using-output-of-non-primeable-wire.md

Create no-wire-adapter-of-resource-cannot-be-primed.md

Create no-missing-resource-cannot-prime-wire-adapter.md

Create no-wire-config-property-uses-getter-function-returning-non-literal.md

Create no-wire-config-property-uses-getter-function-returning-inaccessible-import.md

Create no-class-refers-to-parent-class-from-unsupported-namespace.md

Create no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.md

Create no-wire-config-references-non-local-property-reactive-value.md

Create no-composition-on-unanalyzable-property-from-unresolvable-wire.md

Create no-composition-on-unanalyzable-property-non-public.md

Create no-composition-on-unanalyzable-getter-property.md

Create no-composition-on-unanalyzable-property-missing.md

Create no-wire-config-property-circular-wire-dependency.md

Create no-iterate-on-unanalyzable-getter-property.md

Create no-conditional-using-unanalyzable-non-public-property.md

Create no-assignment-expression-for-external-components.md

Create no-tagged-template-expression-contains-unsupported-namespace.md

Create no-getter-contains-more-than-return-statement.md

Create no-expression-contains-module-level-variable-ref.md

Create no-call-expression-references-unsupported-namespace.md

Create no-eval-usage.md

Create no-reference-to-class-functions.md

Create no-reference-to-module-functions.md

Create no-functions-declared-within-getter-method.md

Create no-unsupported-member-variable-in-member-expression.md

Create no-member-expression-reference-to-non-existent-member-variable.md

Create no-member-expression-reference-to-unsupported-namespace-reference.md

Create no-member-expression-contains-non-portable-identifier.md

Create no-member-expression-reference-to-super-class.md

Create no-member-expression-reference-to-unsupported-global.md

Create no-reference-to-unsupported-namespace-reference.md

Create no-image-reference-unanalyzable-source-property.md

Create no-image-reference-missing-source-property.md

Update no-member-expression-reference-to-super-class.md

Delete no-conditional-using-property-from-unresolvable-wire.md

Update no-unresolved-parent-class-reference.md

Update no-private-wire-config-property.md

Update no-wire-configuration-property-using-output-of-non-primeable-wire.md

Update no-composition-on-unanalyzable-property-from-unresolvable-wire.md

Update no-composition-on-unanalyzable-property-non-public.md

Update no-composition-on-unanalyzable-getter-property.md

Update no-composition-on-unanalyzable-property-missing.md

Delete no-iterate-on-unanalyzable-getter-property.md

Delete no-conditional-using-unanalyzable-non-public-property.md

Update no-assignment-expression-for-external-components.md

Update no-getter-contains-more-than-return-statement.md

Update no-expression-contains-module-level-variable-ref.md

Update no-member-expression-contains-non-portable-identifier.md

Update no-member-expression-reference-to-super-class.md

Delete no-image-reference-unanalyzable-source-property.md

Delete no-image-reference-missing-source-property.md

Create no-render-function-contains-more-than-return-statement.md

Create no-render-function-return-statement.md

create first rule file in new docs folder

Update no-assignment-expression-assigns-value-to-member-variable.md

remove severity info

Removed 'Details' heading

attempting table

table take 2

removed error code from title and duplicated details

table looked bad

added "error" to title

remove error code from doc