### PR TITLE
Remove old rules from the recommendation.

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -34,22 +34,7 @@ module.exports = {
         '@salesforce/lwc-graph-analyzer/no-unsupported-member-variable-in-member-expression':
             'warn',
         '@salesforce/lwc-graph-analyzer/no-multiple-template-files': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-conditional-using-unanalyzable-non-public-property':
-            'warn',
-        '@salesforce/lwc-graph-analyzer/no-conditional-on-unanalyzable-getter-property': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-conditional-using-property-from-unresolvable-wire':
-            'warn',
-        '@salesforce/lwc-graph-analyzer/no-image-reference-unanalyzable-source-property': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-image-reference-missing-source-property': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-iterate-on-unanalyzable-getter-property': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-iterate-on-unanalyzable-property-from-unresolvable-wire':
-            'warn',
         '@salesforce/lwc-graph-analyzer/no-undefined-wire-config-property': 'warn',
-        '@salesforce/lwc-graph-analyzer/no-iterate-on-unanalyzable-property-from-non-public-property':
-            'warn',
-        '@salesforce/lwc-graph-analyzer/no-conditional-on-unanalyzable-non-public-getter-property':
-            'warn',
-        '@salesforce/lwc-graph-analyzer/no-iterate-on-unanalyzable-property': 'warn',
         '@salesforce/lwc-graph-analyzer/no-assignment-expression-for-external-components': 'warn',
         '@salesforce/lwc-graph-analyzer/no-tagged-template-expression-contains-unsupported-namespace':
             'warn',


### PR DESCRIPTION
Left over old rules in the recommendation made plugin fail to work when the plugin was pulled into a project.