### PR TITLE
Adding doc url to the rules.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
         "node": true
     },
     "parserOptions": {
-        "ecmaVersion": 6
+        "ecmaVersion": 2018
     },
     "rules": {
         "strict": ["error", "global"]

--- a/.eslintrc
+++ b/.eslintrc
@@ -19,7 +19,7 @@
         "node": true
     },
     "parserOptions": {
-        "ecmaVersion": 2018
+        "ecmaVersion": 6
     },
     "rules": {
         "strict": ["error", "global"]

--- a/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
+++ b/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
+++ b/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
+++ b/lib/rules/no-assignment-expression-assigns-value-to-member-variable.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-assignment-expression-for-external-components.js
+++ b/lib/rules/no-assignment-expression-for-external-components.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-assignment-expression-for-external-components.js
+++ b/lib/rules/no-assignment-expression-for-external-components.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-assignment-expression-for-external-components.js
+++ b/lib/rules/no-assignment-expression-for-external-components.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-assignment-expression-for-external-components.js
+++ b/lib/rules/no-assignment-expression-for-external-components.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-call-expression-references-unsupported-namespace.js
+++ b/lib/rules/no-call-expression-references-unsupported-namespace.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-call-expression-references-unsupported-namespace.js
+++ b/lib/rules/no-call-expression-references-unsupported-namespace.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-call-expression-references-unsupported-namespace.js
+++ b/lib/rules/no-call-expression-references-unsupported-namespace.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-call-expression-references-unsupported-namespace.js
+++ b/lib/rules/no-call-expression-references-unsupported-namespace.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
+++ b/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
+++ b/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
+++ b/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
+++ b/lib/rules/no-class-refers-to-parent-class-from-unsupported-namespace.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-getter-property.js
+++ b/lib/rules/no-composition-on-unanalyzable-getter-property.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-getter-property.js
+++ b/lib/rules/no-composition-on-unanalyzable-getter-property.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-composition-on-unanalyzable-getter-property.js
+++ b/lib/rules/no-composition-on-unanalyzable-getter-property.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-composition-on-unanalyzable-getter-property.js
+++ b/lib/rules/no-composition-on-unanalyzable-getter-property.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-from-unresolvable-wire.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-missing.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-missing.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-missing.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-missing.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-missing.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-missing.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-missing.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-missing.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-non-public.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-non-public.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-composition-on-unanalyzable-property-non-public.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-non-public.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-non-public.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-non-public.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-composition-on-unanalyzable-property-non-public.js
+++ b/lib/rules/no-composition-on-unanalyzable-property-non-public.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-eval-usage.js
+++ b/lib/rules/no-eval-usage.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-eval-usage.js
+++ b/lib/rules/no-eval-usage.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-eval-usage.js
+++ b/lib/rules/no-eval-usage.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-eval-usage.js
+++ b/lib/rules/no-eval-usage.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-expression-contains-module-level-variable-ref.js
+++ b/lib/rules/no-expression-contains-module-level-variable-ref.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-expression-contains-module-level-variable-ref.js
+++ b/lib/rules/no-expression-contains-module-level-variable-ref.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-expression-contains-module-level-variable-ref.js
+++ b/lib/rules/no-expression-contains-module-level-variable-ref.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-expression-contains-module-level-variable-ref.js
+++ b/lib/rules/no-expression-contains-module-level-variable-ref.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-functions-declared-within-getter-method.js
+++ b/lib/rules/no-functions-declared-within-getter-method.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-functions-declared-within-getter-method.js
+++ b/lib/rules/no-functions-declared-within-getter-method.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-functions-declared-within-getter-method.js
+++ b/lib/rules/no-functions-declared-within-getter-method.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-functions-declared-within-getter-method.js
+++ b/lib/rules/no-functions-declared-within-getter-method.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-getter-contains-more-than-return-statement.js
+++ b/lib/rules/no-getter-contains-more-than-return-statement.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-getter-contains-more-than-return-statement.js
+++ b/lib/rules/no-getter-contains-more-than-return-statement.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-getter-contains-more-than-return-statement.js
+++ b/lib/rules/no-getter-contains-more-than-return-statement.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-getter-contains-more-than-return-statement.js
+++ b/lib/rules/no-getter-contains-more-than-return-statement.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-contains-non-portable-identifier.js
+++ b/lib/rules/no-member-expression-contains-non-portable-identifier.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-contains-non-portable-identifier.js
+++ b/lib/rules/no-member-expression-contains-non-portable-identifier.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-member-expression-contains-non-portable-identifier.js
+++ b/lib/rules/no-member-expression-contains-non-portable-identifier.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-member-expression-contains-non-portable-identifier.js
+++ b/lib/rules/no-member-expression-contains-non-portable-identifier.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
+++ b/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
+++ b/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
+++ b/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
+++ b/lib/rules/no-member-expression-reference-to-non-existent-member-variable.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-super-class.js
+++ b/lib/rules/no-member-expression-reference-to-super-class.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-super-class.js
+++ b/lib/rules/no-member-expression-reference-to-super-class.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-member-expression-reference-to-super-class.js
+++ b/lib/rules/no-member-expression-reference-to-super-class.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-member-expression-reference-to-super-class.js
+++ b/lib/rules/no-member-expression-reference-to-super-class.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-unsupported-global.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-global.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-unsupported-global.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-global.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-member-expression-reference-to-unsupported-global.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-global.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-member-expression-reference-to-unsupported-global.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-global.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-member-expression-reference-to-unsupported-namespace-reference.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
+++ b/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
+++ b/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
+++ b/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
+++ b/lib/rules/no-missing-resource-cannot-prime-wire-adapter.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-multiple-template-files.js
+++ b/lib/rules/no-multiple-template-files.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-multiple-template-files.js
+++ b/lib/rules/no-multiple-template-files.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-multiple-template-files.js
+++ b/lib/rules/no-multiple-template-files.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-multiple-template-files.js
+++ b/lib/rules/no-multiple-template-files.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-private-wire-config-property.js
+++ b/lib/rules/no-private-wire-config-property.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-private-wire-config-property.js
+++ b/lib/rules/no-private-wire-config-property.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-private-wire-config-property.js
+++ b/lib/rules/no-private-wire-config-property.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-private-wire-config-property.js
+++ b/lib/rules/no-private-wire-config-property.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-class-functions.js
+++ b/lib/rules/no-reference-to-class-functions.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-class-functions.js
+++ b/lib/rules/no-reference-to-class-functions.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-reference-to-class-functions.js
+++ b/lib/rules/no-reference-to-class-functions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-reference-to-class-functions.js
+++ b/lib/rules/no-reference-to-class-functions.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-module-functions.js
+++ b/lib/rules/no-reference-to-module-functions.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-module-functions.js
+++ b/lib/rules/no-reference-to-module-functions.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-reference-to-module-functions.js
+++ b/lib/rules/no-reference-to-module-functions.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-reference-to-module-functions.js
+++ b/lib/rules/no-reference-to-module-functions.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-reference-to-unsupported-namespace-reference.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-reference-to-unsupported-namespace-reference.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-reference-to-unsupported-namespace-reference.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-reference-to-unsupported-namespace-reference.js
+++ b/lib/rules/no-reference-to-unsupported-namespace-reference.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-contains-more-than-return-statement.js
+++ b/lib/rules/no-render-function-contains-more-than-return-statement.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-contains-more-than-return-statement.js
+++ b/lib/rules/no-render-function-contains-more-than-return-statement.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-render-function-contains-more-than-return-statement.js
+++ b/lib/rules/no-render-function-contains-more-than-return-statement.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-contains-more-than-return-statement.js
+++ b/lib/rules/no-render-function-contains-more-than-return-statement.js
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
+++ b/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
+++ b/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
+++ b/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
+++ b/lib/rules/no-render-function-return-statement-not-returning-imported-template.js
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-render-function-return-statement.js
+++ b/lib/rules/no-render-function-return-statement.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-return-statement.js
+++ b/lib/rules/no-render-function-return-statement.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-render-function-return-statement.js
+++ b/lib/rules/no-render-function-return-statement.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-render-function-return-statement.js
+++ b/lib/rules/no-render-function-return-statement.js
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
+++ b/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
+++ b/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
+++ b/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
+++ b/lib/rules/no-tagged-template-expression-contains-unsupported-namespace.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-undefined-wire-config-property.js
+++ b/lib/rules/no-undefined-wire-config-property.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-undefined-wire-config-property.js
+++ b/lib/rules/no-undefined-wire-config-property.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-undefined-wire-config-property.js
+++ b/lib/rules/no-undefined-wire-config-property.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-undefined-wire-config-property.js
+++ b/lib/rules/no-undefined-wire-config-property.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-unresolved-parent-class-reference.js
+++ b/lib/rules/no-unresolved-parent-class-reference.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-unresolved-parent-class-reference.js
+++ b/lib/rules/no-unresolved-parent-class-reference.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-unresolved-parent-class-reference.js
+++ b/lib/rules/no-unresolved-parent-class-reference.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-unresolved-parent-class-reference.js
+++ b/lib/rules/no-unresolved-parent-class-reference.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-unsupported-member-variable-in-member-expression.js
+++ b/lib/rules/no-unsupported-member-variable-in-member-expression.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-unsupported-member-variable-in-member-expression.js
+++ b/lib/rules/no-unsupported-member-variable-in-member-expression.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-unsupported-member-variable-in-member-expression.js
+++ b/lib/rules/no-unsupported-member-variable-in-member-expression.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-unsupported-member-variable-in-member-expression.js
+++ b/lib/rules/no-unsupported-member-variable-in-member-expression.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
+++ b/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
+++ b/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
+++ b/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
+++ b/lib/rules/no-wire-adapter-of-resource-cannot-be-primed.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-circular-wire-dependency.js
+++ b/lib/rules/no-wire-config-property-circular-wire-dependency.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-circular-wire-dependency.js
+++ b/lib/rules/no-wire-config-property-circular-wire-dependency.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-config-property-circular-wire-dependency.js
+++ b/lib/rules/no-wire-config-property-circular-wire-dependency.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-config-property-circular-wire-dependency.js
+++ b/lib/rules/no-wire-config-property-circular-wire-dependency.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-inaccessible-import.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
+++ b/lib/rules/no-wire-config-property-uses-getter-function-returning-non-literal.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
+++ b/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
+++ b/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
+++ b/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
+++ b/lib/rules/no-wire-config-property-uses-imported-artifact-from-unsupported-namespace.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
+++ b/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
+++ b/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
+++ b/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
+++ b/lib/rules/no-wire-config-references-non-local-property-reactive-value.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
+++ b/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
@@ -7,7 +7,7 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { createRule } = require('../util/createRule');
+const ruleDefinition = createRule(__filename);
 
 module.exports = ruleDefinition;

--- a/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
+++ b/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
@@ -11,5 +11,5 @@ const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    ...ruleDefinition    
+    ...ruleDefinition
 };

--- a/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
+++ b/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2022, salesforce.com, inc.
+ * Copyright (c) 2023, salesforce.com, inc.
  * All rights reserved.
  * SPDX-License-Identifier: MIT
  * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
@@ -7,15 +7,9 @@
 
 'use strict';
 
-const { analyzeLWC } = require('../util/helper');
+const { ruleBase } = require('../util/ruleBase');
+const ruleDefinition = ruleBase(__filename);
 
 module.exports = {
-    meta: {
-        type: 'problem',
-        schema: []
-    },
-    create: function (context) {
-        analyzeLWC(context, __filename);
-        return {};
-    }
+    ...ruleDefinition    
 };

--- a/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
+++ b/lib/rules/no-wire-configuration-property-using-output-of-non-primeable-wire.js
@@ -10,6 +10,4 @@
 const { ruleBase } = require('../util/ruleBase');
 const ruleDefinition = ruleBase(__filename);
 
-module.exports = {
-    ...ruleDefinition
-};
+module.exports = ruleDefinition;

--- a/lib/util/createRule.js
+++ b/lib/util/createRule.js
@@ -8,10 +8,10 @@
 'use strict';
 
 const path = require('path');
-const { docUrl } = require('../util/doc-url');
-const { analyzeLWC } = require('../util/helper');
+const { docUrl } = require('./doc-url');
+const { analyzeLWC } = require('./helper');
 
-function ruleBase(filename) {
+function createRule(filename) {
     return {
         meta: {
             docs: {
@@ -29,5 +29,5 @@ function ruleBase(filename) {
 }
 
 module.exports = {
-    ruleBase
-};
+    createRule
+}

--- a/lib/util/createRule.js
+++ b/lib/util/createRule.js
@@ -30,4 +30,4 @@ function createRule(filename) {
 
 module.exports = {
     createRule
-}
+};

--- a/lib/util/doc-url.js
+++ b/lib/util/doc-url.js
@@ -7,9 +7,12 @@
 
 'use strict';
 
-const { ruleBase } = require('../util/ruleBase');
-const ruleDefinition = ruleBase(__filename);
+const { version, repository } = require('../../package.json');
+
+function docUrl(ruleName) {
+    return `${repository.url}/blob/${version}/docs/rules/${ruleName}.md`;
+}
 
 module.exports = {
-    ...ruleDefinition    
+    docUrl,
 };

--- a/lib/util/doc-url.js
+++ b/lib/util/doc-url.js
@@ -7,10 +7,10 @@
 
 'use strict';
 
-const { version, repository } = require('../../package.json');
+const { version, homepage } = require('../../package.json');
 
 function docUrl(ruleName) {
-    return `${repository.url}/blob/${version}/lib/docs/${ruleName}.md`;
+    return `${homepage}/blob/${version}/lib/docs/${ruleName}.md`;
 }
 
 module.exports = {

--- a/lib/util/doc-url.js
+++ b/lib/util/doc-url.js
@@ -10,9 +10,9 @@
 const { version, repository } = require('../../package.json');
 
 function docUrl(ruleName) {
-    return `${repository.url}/blob/${version}/docs/rules/${ruleName}.md`;
+    return `${repository.url}/blob/${version}/lib/docs/${ruleName}.md`;
 }
 
 module.exports = {
-    docUrl,
+    docUrl
 };

--- a/lib/util/ruleBase.js
+++ b/lib/util/ruleBase.js
@@ -1,0 +1,33 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+'use strict';
+
+const path = require('path');
+const { docUrl } = require('../util/doc-url');
+const { analyzeLWC } = require('../util/helper');
+
+function ruleBase(filename) {
+    return {
+        meta: {
+            docs: {
+                recommeded: false,
+                url: docUrl(path.parse(filename))
+            },
+            type: 'problem',
+            schema: []
+        },
+        create: function (context) {
+            analyzeLWC(context, filename);
+            return {};
+        }
+    };
+}
+
+module.exports = {
+    ruleBase
+}

--- a/lib/util/ruleBase.js
+++ b/lib/util/ruleBase.js
@@ -16,7 +16,7 @@ function ruleBase(filename) {
         meta: {
             docs: {
                 recommeded: false,
-                url: docUrl(path.parse(filename))
+                url: docUrl(path.parse(filename).name)
             },
             type: 'problem',
             schema: []
@@ -30,4 +30,4 @@ function ruleBase(filename) {
 
 module.exports = {
     ruleBase
-}
+};

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/salesforce/eslint-plugin-lwc-graph-analyzer.git"
+        "url": "https://github.com/salesforce/eslint-plugin-lwc-graph-analyzer"
     },
     "main": "lib/index.js",
     "directories": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "license": "MIT",
     "repository": {
         "type": "git",
-        "url": "https://github.com/salesforce/eslint-plugin-lwc-graph-analyzer"
+        "url": "https://github.com/salesforce/eslint-plugin-lwc-graph-analyzer.git"
     },
     "main": "lib/index.js",
     "directories": {


### PR DESCRIPTION
The generated doc urls in rules will offer links in VSCode's popups that can jump to the documentation in this repo.

Refactored code so that all rules will use the same base object to share.