### PR TITLE
Cleaning up README instructions

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,3 @@
 # Comment line immediately above ownership line is reserved for related other information. Please be careful while editing.
 #ECCN:Open Source
-* @khawkins @dbreese @AndrewHuffman @sfdctaka @maliroteh-sf
+* @khawkins @dbreese @sfdctaka @maliroteh-sf @salesforce/lasr

--- a/README.md
+++ b/README.md
@@ -1,31 +1,28 @@
 # @salesforce/eslint-plugin-lwc-graph-analyzer
 
-> An ESLint plugin to analyze the data flow graph of a Lightning web component, to ensure the component's offline-ability.
+`eslint-plugin-lwc-graph-analyzer` is an ESLint plugin that analyzes the data flow graph of a Lightning web component, to ensure the component can be statically analyzed, a requirement for LWC data priming and offline use cases.
 
 ## Should I use this plugin?
 
-This plugin wraps the [Komaci static analyzer](https://www.npmjs.com/package/@komaci/static-analyzer), which looks at your component's `@wire` definitions and validates whether the component is offline-able or not. You should use this plugin to ensure that your Lightning web component can take full advantage of the Lightning SDK.
+This plugin wraps the [Komaci static analyzer](https://www.npmjs.com/package/@komaci/static-analyzer), which interrogates your Lightning web component's `@wire` definitions and dependency graph, and validates whether these can be statically analyzed. Static analyzability is a requirement for LWCs to support offline use cases. Using this plugin will help you catch any exceptions to your component's static analyzability, ensuring that it can take full advantage of the Lightning SDK's offline capabilities.
 
 ## Installation
 
-This plugin has not yet been published to a public registry. Instead, clone the repo on your machine.
+To add this plugin to your package/project, install it with your favorite Node.js package manager.
 
-```
-git clone https://github.com/salesforce/eslint-plugin-lwc-graph-analyzer.git
-cd eslint-plugin-lwc-graph-analyzer
-yarn install
-yarn test // Ensures your installation is working properly
-```
-
-Then, from the root of your LWC project run to add the plugin to your `package.json`:
-
+### yarn
 ```sh
-$ yarn add --dev <path to cloned repo>/eslint-plugin-lwc-graph-analyzer
+$ yarn add --dev @salesforce/eslint-plugin-lwc-graph-analyzer
 ```
 
-## Usage
+### npm
+```sh
+$ npm install --save-dev @salesforce/eslint-plugin-lwc-graph-analyzer
+```
 
-Here's an example `.eslintrc` that configures the plugin. Extending the `plugin:@salesforce/lwc-graph-analyzer/recommended` config will enable static analysis on all `.js` and `.html` files used in Lightning web components.
+## Configuration
+
+Here's an example snippet of a `.eslintrc.json` configuration file, that will configure the `eslint-plugin-lwc-graph-analyzer` plugin. Extending the `plugin:@salesforce/lwc-graph-analyzer/recommended` ESLint configuration will enable static analysis on all `.js` and `.html` files used in your Lightning web components.
 
 ```json
 {
@@ -33,4 +30,6 @@ Here's an example `.eslintrc` that configures the plugin. Extending the `plugin:
 }
 ```
 
-If you have `.eslintignore` in your project do not add an entry to ignore html files. This will cause the plugin to skip linting on LWC bundles that include html templates.
+In an SFDX project, you would most commonly add this configuration at the root of your LWC "tree"—which by default resides at `force-app/main/default/lwc/`—since the plugin's analysis applies specifically to Lightning web components.
+
+**Note:** If you have a `.eslintignore` configuration in your project, do *not* add an entry to ignore HTML files. This will cause the plugin to skip linting on LWC bundles that include HTML templates. There are a number of Komaci-based static analysis rules that apply specifically to the HTML template of a Lightning web component bundle.

--- a/README.md
+++ b/README.md
@@ -11,11 +11,13 @@ This plugin wraps the [Komaci static analyzer](https://www.npmjs.com/package/@ko
 To add this plugin to your package/project, install it with your favorite Node.js package manager.
 
 ### yarn
+
 ```sh
 $ yarn add --dev @salesforce/eslint-plugin-lwc-graph-analyzer
 ```
 
 ### npm
+
 ```sh
 $ npm install --save-dev @salesforce/eslint-plugin-lwc-graph-analyzer
 ```
@@ -32,4 +34,4 @@ Here's an example snippet of a `.eslintrc.json` configuration file, that will co
 
 In an SFDX project, you would most commonly add this configuration at the root of your LWC "tree"—which by default resides at `force-app/main/default/lwc/`—since the plugin's analysis applies specifically to Lightning web components.
 
-**Note:** If you have a `.eslintignore` configuration in your project, do *not* add an entry to ignore HTML files. This will cause the plugin to skip linting on LWC bundles that include HTML templates. There are a number of Komaci-based static analysis rules that apply specifically to the HTML template of a Lightning web component bundle.
+**Note:** If you have a `.eslintignore` configuration in your project, do _not_ add an entry to ignore HTML files. This will cause the plugin to skip linting on LWC bundles that include HTML templates. There are a number of Komaci-based static analysis rules that apply specifically to the HTML template of a Lightning web component bundle.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/eslint-plugin-lwc-graph-analyzer",
-    "version": "0.6.1",
+    "version": "0.6.2",
     "description": "ESLint plugin to analyze data graph in a LWC component",
     "contributors": [
         {


### PR DESCRIPTION
- Most pressing was to remove the verbiage that said the plugin wasn't published, in favor of the simpler workflow of installing the now-published package.
- The rest was just miscellaneous wordsmithing.