### PR TITLE
Add rules to recommended.

### DIFF
--- a/lib/configs/recommended.js
+++ b/lib/configs/recommended.js
@@ -52,6 +52,16 @@ module.exports = {
             'warn',
         '@salesforce/lwc-graph-analyzer/no-member-expression-reference-to-super-class': 'warn',
         '@salesforce/lwc-graph-analyzer/no-member-expression-reference-to-unsupported-global':
-            'warn'
+            'warn',
+        '@salesforce/lwc-graph-analyzer/no-composition-on-unanalyzable-getter-property': 'warn',
+        '@salesforce/lwc-graph-analyzer/no-composition-on-unanalyzable-property-from-unresolvable-wire':
+            'warn',
+        '@salesforce/lwc-graph-analyzer/no-composition-on-unanalyzable-property-missing': 'warn',
+        '@salesforce/lwc-graph-analyzer/no-composition-on-unanalyzable-property-non-public': 'warn',
+        '@salesforce/lwc-graph-analyzer/no-render-function-contains-more-than-return-statement':
+            'warn',
+        '@salesforce/lwc-graph-analyzer/no-render-function-return-statement-not-returning-imported-template':
+            'warn',
+        '@salesforce/lwc-graph-analyzer/no-render-function-return-statement': 'warn'
     }
 };

--- a/test/plugin.js
+++ b/test/plugin.js
@@ -43,4 +43,24 @@ describe('Plugin', function () {
         });
         assert.equal(keysRulesEqual, true);
     });
+
+    it('recommended rules count equals the number of existing rules', function () {
+        assert.equal(plugin.configs.recommended.rules.length, plugin.rules.length);
+
+        let recommendedRules = Object.keys(plugin.configs.recommended.rules);
+
+        // Strip out scoped module path then sort the array.
+        recommendedRules = recommendedRules
+            .map((rule) => {
+                return rule.replace('@salesforce/lwc-graph-analyzer/', '');
+            })
+            .sort();
+
+        const rules = Object.keys(plugin.rules).sort();
+
+        const rulesEqual = rules.some((element, index) => {
+            return element === recommendedRules[index];
+        });
+        assert.equal(rulesEqual, true);
+    });
 });


### PR DESCRIPTION
Some rules were missing from the list of recommended rules. This was causing some lint errors to be ignored.