### PR TITLE
Disable lint for bundle when eslint-disable is used

### DIFF
--- a/lib/processor.js
+++ b/lib/processor.js
@@ -89,8 +89,13 @@ function preprocess(text, filename) {
         // then it will use the report instead rather than trying to run Komaci analysis again.
         addReport(filename, eslintReports);
 
-        // Have at least one fake item in the array so that eslint will continue its process further.
-        return [{ text: '', filename }];
+        // Continue linting the text only for Javascript. For html, further linting cannot be
+        // performed by eslint so pass empty string.
+        if (ext === '.html') {
+            return [{ text: '', filename }];
+        } else {
+            return [{ text: text, filename }];
+        }
     }
 }
 

--- a/lib/util/helper.js
+++ b/lib/util/helper.js
@@ -21,7 +21,6 @@ function rangeToLoc(range) {
     return {
         start: {
             // Komaci reports line number using 0 based index so adjust it by 1.
-            // GUS ticket: https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00000uV9xtYAC/view
             line: line + 1,
             column: column
         },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@salesforce/eslint-plugin-lwc-graph-analyzer",
-    "version": "0.7.0",
+    "version": "0.7.1",
     "description": "ESLint plugin to analyze data graph in a LWC component",
     "contributors": [
         {

--- a/test/lib/rules/artifacts-combined-files/fileUpload/no-getter-contains-more-than-return-statement.js
+++ b/test/lib/rules/artifacts-combined-files/fileUpload/no-getter-contains-more-than-return-statement.js
@@ -1,0 +1,20 @@
+/*
+ * Copyright (c) 2023, salesforce.com, inc.
+ * All rights reserved.
+ * SPDX-License-Identifier: MIT
+ * For full license text, see the LICENSE file in the repo root or https://opensource.org/licenses/MIT
+ */
+
+'use strict';
+
+const { assert } = require('chai');
+const { lintBundle } = require('../helper');
+
+describe('Bundle linting', function () {
+    it('should return correct errors', function () {
+        const messages = lintBundle(__filename, 'test.js');
+
+        // Allint warnings are suppressed using variants of eslint-disable
+        assert.equal(messages.length, 0);
+    });
+});

--- a/test/lib/rules/artifacts-combined-files/fileUpload/no-getter-contains-more-than-return-statement.js
+++ b/test/lib/rules/artifacts-combined-files/fileUpload/no-getter-contains-more-than-return-statement.js
@@ -14,7 +14,7 @@ describe('Bundle linting', function () {
     it('should return correct errors', function () {
         const messages = lintBundle(__filename, 'test.js');
 
-        // Allint warnings are suppressed using variants of eslint-disable
+        // All lint warnings are suppressed using variants of eslint-disable
         assert.equal(messages.length, 0);
     });
 });

--- a/test/lib/rules/artifacts-combined-files/fileUpload/test.html
+++ b/test/lib/rules/artifacts-combined-files/fileUpload/test.html
@@ -1,0 +1,49 @@
+<template>
+    <h1>File Upload</h1>
+
+        <div>
+            <lightning-input
+                type="file"
+                name="fileUploader"
+                label="Pick file to upload"
+                multiple="true"
+                accept="*/*"
+                onchange={handleInputChange}
+            >
+            </lightning-input>
+        </div>
+
+        <!-- Currently komaci only supports the if:true= instead of the new lwc:if directive -->
+        <div if:true={fileName}>
+            <p>Selected file:</p>
+            <p>{fileName}</p>
+            <div class="inputs">
+                <lightning-input
+                    type="text"
+                    label="Title"
+                    value={titleValue}
+                    onchange={handleTitleInputChange}
+                ></lightning-input>
+                <lightning-input
+                    type="text"
+                    label="Description"
+                    value={descriptionValue}
+                    onchange={handleDescriptionInputChange}
+                ></lightning-input>
+            </div>
+            <button
+                class="slds-button slds-button_brand slds-var-m-top_medium"
+                disabled={uploadingFile}
+                onclick={handleUploadClick}
+            >
+                Upload
+            </button>
+        </div>
+
+        <!-- Currently komaci only supports the if:true= instead of the new lwc:if directive -->
+        <div if:true={errorMessage}>
+            <lightning-card title="Error">
+                <div class="card-body">{errorMessage}</div>
+            </lightning-card>
+        </div>
+</template>

--- a/test/lib/rules/artifacts-combined-files/fileUpload/test.js
+++ b/test/lib/rules/artifacts-combined-files/fileUpload/test.js
@@ -137,7 +137,7 @@ export default class FileUpload extends LightningElement {
     }
 
     async createCdl(recordId, contentDocumentId) {
-        await createRecord({
+        return createRecord({
             apiName: 'ContentDocumentLink',
             fields: {
                 LinkedEntityId: recordId,

--- a/test/lib/rules/artifacts-combined-files/fileUpload/test.js
+++ b/test/lib/rules/artifacts-combined-files/fileUpload/test.js
@@ -1,0 +1,167 @@
+import { LightningElement, api, track, wire } from 'lwc';
+import { unstable_createContentDocumentAndVersion, createRecord } from 'lightning/uiRecordApi';
+import { ShowToastEvent } from 'lightning/platformShowToastEvent';
+
+export default class FileUpload extends LightningElement {
+    @api
+    recordId;
+
+    @track
+    files = undefined;
+
+    @track
+    uploadingFile = false;
+
+    @track
+    titleValue = '';
+
+    @track
+    descriptionValue = '';
+
+    @track
+    errorMessage = '';
+
+    get recordId() {
+        return recordId;
+    }
+
+    /* eslint-disable */
+    get fileName() {
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+    /* eslint-enable */
+
+    /* eslint-disable no-getter-contains-more-than-return-statement */
+    get fileName1() {
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+    /* eslint-enable no-getter-contains-more-than-return-statement */
+
+    // eslint-disable-next-line
+    get fileName2() {
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+
+    // eslint-disable-next-line no-getter-contains-more-than-return-statement
+    get fileName3() {
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+
+    // prettier-ignore
+    get fileName4() { // eslint-disable-line
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+
+    // prettier-ignore
+    get fileName5() { // eslint-disable-line no-getter-contains-more-than-return-statement
+        const file = this.files && this.files[0];
+        if (file) {
+            return file.name;
+        }
+        return undefined;
+    }
+
+    handleInputChange(event) {
+        this.files = event.detail.files;
+        this.titleValue = this.fileName;
+    }
+
+    handleTitleInputChange(event) {
+        this.titleValue = event.detail.value;
+    }
+
+    handleDescriptionInputChange(event) {
+        this.descriptionValue = event.detail.value;
+    }
+
+    resetInputs() {
+        this.files = [];
+        this.titleValue = '';
+        this.descriptionValue = '';
+        this.errorMessage = '';
+    }
+
+    // Handle the user uploading a file
+    async handleUploadClick() {
+        if (this.uploadingFile) {
+            return;
+        }
+
+        const file = this.files && this.files[0];
+        if (!file) {
+            return;
+        }
+
+        try {
+            this.uploadingFile = true;
+
+            // Create a ContentDocumentLink (CDL) to associate the uploaded file
+            // to the Files Related List of a record, like a Work Order.
+            const contentDocumentAndVersion = await unstable_createContentDocumentAndVersion({
+                title: this.titleValue,
+                description: this.descriptionValue,
+                fileData: file
+            });
+
+            if (this.recordId) {
+                const contentDocumentId = contentDocumentAndVersion.contentDocument.id;
+                await this.createCdl(this.recordId, contentDocumentId);
+            }
+            this.resetInputs();
+        } catch (error) {
+            console.error(error);
+            this.errorMessage = error;
+        } finally {
+            this.uploadingFile = false;
+        }
+    }
+
+    async createCdl(recordId, contentDocumentId) {
+        await createRecord({
+            apiName: 'ContentDocumentLink',
+            fields: {
+                LinkedEntityId: recordId,
+                ContentDocumentId: contentDocumentId,
+                ShareType: 'V'
+            }
+        })
+            .then(() => {
+                this.dispatchEvent(
+                    new ShowToastEvent({
+                        title: 'Success',
+                        message: 'File attached',
+                        variant: 'success'
+                    })
+                );
+            })
+            .catch((e) => {
+                this.dispatchEvent(
+                    new ShowToastEvent({
+                        title: 'Error uploading file',
+                        message: e.body.message,
+                        variant: 'error'
+                    })
+                );
+            });
+    }
+}


### PR DESCRIPTION
When LWC bundle was preprocessed the source code text was not passed to the processing pipeline. This didn't allow eslint to properly suppress lint warnings when `eslint-disable` variants were used.